### PR TITLE
Add provider and supply management to admin panel

### DIFF
--- a/app/Http/Controllers/Admin/ProviderController.php
+++ b/app/Http/Controllers/Admin/ProviderController.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Provider;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class ProviderController extends Controller
+{
+    /**
+     * Display a listing of the providers.
+     */
+    public function index(): View
+    {
+        $providers = Provider::query()
+            ->withCount('supplies')
+            ->orderBy('name')
+            ->paginate(10);
+
+        return view('admin.providers.index', compact('providers'));
+    }
+
+    /**
+     * Show the form for creating a new provider.
+     */
+    public function create(): View
+    {
+        return view('admin.providers.create');
+    }
+
+    /**
+     * Store a newly created provider in storage.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'contact_name' => ['nullable', 'string', 'max:255'],
+            'email' => ['nullable', 'email', 'max:255'],
+            'phone' => ['nullable', 'string', 'max:50'],
+            'address' => ['nullable', 'string', 'max:255'],
+            'notes' => ['nullable', 'string'],
+        ]);
+
+        $provider = Provider::create($validated);
+
+        return redirect()
+            ->route('admin.providers.show', $provider)
+            ->with('status', 'Proveedor creado correctamente.');
+    }
+
+    /**
+     * Display the specified provider.
+     */
+    public function show(Provider $provider): View
+    {
+        $provider->load(['supplies' => fn ($query) => $query->orderBy('name')]);
+
+        return view('admin.providers.show', compact('provider'));
+    }
+
+    /**
+     * Show the form for editing the specified provider.
+     */
+    public function edit(Provider $provider): View
+    {
+        return view('admin.providers.edit', compact('provider'));
+    }
+
+    /**
+     * Update the specified provider in storage.
+     */
+    public function update(Request $request, Provider $provider): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'contact_name' => ['nullable', 'string', 'max:255'],
+            'email' => ['nullable', 'email', 'max:255'],
+            'phone' => ['nullable', 'string', 'max:50'],
+            'address' => ['nullable', 'string', 'max:255'],
+            'notes' => ['nullable', 'string'],
+        ]);
+
+        $provider->update($validated);
+
+        return redirect()
+            ->route('admin.providers.show', $provider)
+            ->with('status', 'Proveedor actualizado correctamente.');
+    }
+
+    /**
+     * Remove the specified provider from storage.
+     */
+    public function destroy(Provider $provider): RedirectResponse
+    {
+        $provider->delete();
+
+        return redirect()
+            ->route('admin.providers.index')
+            ->with('status', 'Proveedor eliminado correctamente.');
+    }
+}

--- a/app/Http/Controllers/Admin/SupplyController.php
+++ b/app/Http/Controllers/Admin/SupplyController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Provider;
+use App\Models\Supply;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class SupplyController extends Controller
+{
+    /**
+     * Store a newly created supply in storage.
+     */
+    public function store(Request $request, Provider $provider): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'unit' => ['nullable', 'string', 'max:50'],
+            'unit_price' => ['nullable', 'numeric', 'min:0'],
+            'stock' => ['nullable', 'integer', 'min:0'],
+        ]);
+
+        $validated['unit_price'] = $validated['unit_price'] ?? 0;
+        $validated['stock'] = $validated['stock'] ?? 0;
+
+        $provider->supplies()->create($validated);
+
+        return redirect()
+            ->route('admin.providers.show', $provider)
+            ->with('status', 'Insumo agregado correctamente.');
+    }
+
+    /**
+     * Remove the specified supply from storage.
+     */
+    public function destroy(Provider $provider, Supply $supply): RedirectResponse
+    {
+        if ($supply->provider_id !== $provider->id) {
+            abort(404);
+        }
+
+        $supply->delete();
+
+        return redirect()
+            ->route('admin.providers.show', $provider)
+            ->with('status', 'Insumo eliminado correctamente.');
+    }
+}

--- a/app/Models/Provider.php
+++ b/app/Models/Provider.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Provider extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'name',
+        'contact_name',
+        'email',
+        'phone',
+        'address',
+        'notes',
+    ];
+
+    /**
+     * Get the supplies for the provider.
+     */
+    public function supplies(): HasMany
+    {
+        return $this->hasMany(Supply::class);
+    }
+}

--- a/app/Models/Supply.php
+++ b/app/Models/Supply.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Supply extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'name',
+        'description',
+        'unit',
+        'unit_price',
+        'stock',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'unit_price' => 'decimal:2',
+    ];
+
+    /**
+     * Get the provider that owns the supply.
+     */
+    public function provider(): BelongsTo
+    {
+        return $this->belongsTo(Provider::class);
+    }
+}

--- a/database/factories/ProviderFactory.php
+++ b/database/factories/ProviderFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Provider;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Provider>
+ */
+class ProviderFactory extends Factory
+{
+    protected $model = Provider::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->company(),
+            'contact_name' => $this->faker->name(),
+            'email' => $this->faker->unique()->safeEmail(),
+            'phone' => $this->faker->phoneNumber(),
+            'address' => $this->faker->address(),
+            'notes' => $this->faker->sentence(),
+        ];
+    }
+}

--- a/database/migrations/2025_10_01_000000_create_providers_table.php
+++ b/database/migrations/2025_10_01_000000_create_providers_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('providers', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('contact_name')->nullable();
+            $table->string('email')->nullable();
+            $table->string('phone', 50)->nullable();
+            $table->string('address')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('providers');
+    }
+};

--- a/database/migrations/2025_10_01_000100_create_supplies_table.php
+++ b/database/migrations/2025_10_01_000100_create_supplies_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('supplies', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('provider_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->string('unit')->nullable();
+            $table->decimal('unit_price', 10, 2)->default(0);
+            $table->unsignedInteger('stock')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('supplies');
+    }
+};

--- a/resources/views/admin/providers/create.blade.php
+++ b/resources/views/admin/providers/create.blade.php
@@ -1,0 +1,73 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            Nuevo Proveedor
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 dark:text-gray-100">
+                    <form method="POST" action="{{ route('admin.providers.store') }}" class="space-y-6">
+                        @csrf
+
+                        <div>
+                            <x-input-label for="name" value="Nombre" />
+                            <x-text-input id="name" name="name" type="text" class="mt-1 block w-full" required
+                                autofocus value="{{ old('name') }}" />
+                            <x-input-error :messages="$errors->get('name')" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="contact_name" value="Nombre del contacto" />
+                            <x-text-input id="contact_name" name="contact_name" type="text" class="mt-1 block w-full"
+                                value="{{ old('contact_name') }}" />
+                            <x-input-error :messages="$errors->get('contact_name')" class="mt-2" />
+                        </div>
+
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <div>
+                                <x-input-label for="email" value="Correo" />
+                                <x-text-input id="email" name="email" type="email" class="mt-1 block w-full"
+                                    value="{{ old('email') }}" />
+                                <x-input-error :messages="$errors->get('email')" class="mt-2" />
+                            </div>
+
+                            <div>
+                                <x-input-label for="phone" value="Teléfono" />
+                                <x-text-input id="phone" name="phone" type="text" class="mt-1 block w-full"
+                                    value="{{ old('phone') }}" />
+                                <x-input-error :messages="$errors->get('phone')" class="mt-2" />
+                            </div>
+                        </div>
+
+                        <div>
+                            <x-input-label for="address" value="Dirección" />
+                            <x-text-input id="address" name="address" type="text" class="mt-1 block w-full"
+                                value="{{ old('address') }}" />
+                            <x-input-error :messages="$errors->get('address')" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="notes" value="Notas" />
+                            <textarea id="notes" name="notes" rows="4"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:border-gray-700">{{ old('notes') }}</textarea>
+                            <x-input-error :messages="$errors->get('notes')" class="mt-2" />
+                        </div>
+
+                        <div class="flex items-center justify-end gap-4">
+                            <a href="{{ route('admin.providers.index') }}"
+                                class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200">
+                                Cancelar
+                            </a>
+                            <x-primary-button>
+                                Guardar
+                            </x-primary-button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/providers/edit.blade.php
+++ b/resources/views/admin/providers/edit.blade.php
@@ -1,0 +1,92 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            Editar Proveedor
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-4xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 dark:text-gray-100">
+                    <form method="POST" action="{{ route('admin.providers.update', $provider) }}" class="space-y-6">
+                        @csrf
+                        @method('PUT')
+
+                        <div>
+                            <x-input-label for="name" value="Nombre" />
+                            <x-text-input id="name" name="name" type="text" class="mt-1 block w-full" required autofocus
+                                value="{{ old('name', $provider->name) }}" />
+                            <x-input-error :messages="$errors->get('name')" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="contact_name" value="Nombre del contacto" />
+                            <x-text-input id="contact_name" name="contact_name" type="text" class="mt-1 block w-full"
+                                value="{{ old('contact_name', $provider->contact_name) }}" />
+                            <x-input-error :messages="$errors->get('contact_name')" class="mt-2" />
+                        </div>
+
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <div>
+                                <x-input-label for="email" value="Correo" />
+                                <x-text-input id="email" name="email" type="email" class="mt-1 block w-full"
+                                    value="{{ old('email', $provider->email) }}" />
+                                <x-input-error :messages="$errors->get('email')" class="mt-2" />
+                            </div>
+
+                            <div>
+                                <x-input-label for="phone" value="Teléfono" />
+                                <x-text-input id="phone" name="phone" type="text" class="mt-1 block w-full"
+                                    value="{{ old('phone', $provider->phone) }}" />
+                                <x-input-error :messages="$errors->get('phone')" class="mt-2" />
+                            </div>
+                        </div>
+
+                        <div>
+                            <x-input-label for="address" value="Dirección" />
+                            <x-text-input id="address" name="address" type="text" class="mt-1 block w-full"
+                                value="{{ old('address', $provider->address) }}" />
+                            <x-input-error :messages="$errors->get('address')" class="mt-2" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="notes" value="Notas" />
+                            <textarea id="notes" name="notes" rows="4"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:border-gray-700">{{ old('notes', $provider->notes) }}</textarea>
+                            <x-input-error :messages="$errors->get('notes')" class="mt-2" />
+                        </div>
+
+                        <div class="flex items-center justify-between gap-4">
+                            <a href="{{ route('admin.providers.show', $provider) }}"
+                                class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200">
+                                Cancelar
+                            </a>
+
+                            <x-primary-button>
+                                Actualizar
+                            </x-primary-button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 dark:text-gray-100">
+                    <h3 class="text-lg font-semibold mb-4">Eliminar proveedor</h3>
+                    <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                        Esta acción eliminará al proveedor y todos sus insumos registrados.
+                    </p>
+                    <form method="POST" action="{{ route('admin.providers.destroy', $provider) }}"
+                        onsubmit="return confirm('¿Deseas eliminar este proveedor? Esta acción no se puede deshacer.');">
+                        @csrf
+                        @method('DELETE')
+                        <x-danger-button>
+                            Eliminar proveedor
+                        </x-danger-button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/providers/index.blade.php
+++ b/resources/views/admin/providers/index.blade.php
@@ -1,0 +1,84 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex justify-between items-center">
+            <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+                Proveedores
+            </h2>
+            <a href="{{ route('admin.providers.create') }}"
+                class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-500">
+                Nuevo Proveedor
+            </a>
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 dark:text-gray-100">
+                    @if (session('status'))
+                        <div class="mb-4 bg-green-100 dark:bg-green-900 border border-green-400 dark:border-green-600 text-green-700 dark:text-green-300 px-4 py-3 rounded relative"
+                            role="alert">
+                            {{ session('status') }}
+                        </div>
+                    @endif
+
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                            <thead class="bg-gray-50 dark:bg-gray-700">
+                                <tr>
+                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                                        Nombre
+                                    </th>
+                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                                        Contacto
+                                    </th>
+                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                                        Insumos
+                                    </th>
+                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                                        Acciones
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                                @forelse ($providers as $provider)
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">
+                                            {{ $provider->name }}
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                                            {{ $provider->contact_name ?? '—' }}
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                                            {{ $provider->supplies_count }}
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm font-medium space-x-4">
+                                            <a href="{{ route('admin.providers.show', $provider) }}"
+                                                class="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400">
+                                                Ver
+                                            </a>
+                                            <a href="{{ route('admin.providers.edit', $provider) }}"
+                                                class="text-indigo-600 hover:text-indigo-900 dark:text-indigo-400">
+                                                Editar
+                                            </a>
+                                        </td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="4" class="px-6 py-4 whitespace-nowrap text-sm text-center text-gray-500">
+                                            No hay proveedores registrados.
+                                        </td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="mt-6">
+                        {{ $providers->links() }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/admin/providers/show.blade.php
+++ b/resources/views/admin/providers/show.blade.php
@@ -1,0 +1,189 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex justify-between items-center">
+            <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+                {{ $provider->name }}
+            </h2>
+            <div class="flex items-center gap-3">
+                <a href="{{ route('admin.providers.edit', $provider) }}"
+                    class="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-indigo-500">
+                    Editar
+                </a>
+                <a href="{{ route('admin.providers.index') }}"
+                    class="inline-flex items-center px-4 py-2 bg-gray-200 dark:bg-gray-700 border border-transparent rounded-md font-semibold text-xs text-gray-800 dark:text-gray-200 uppercase tracking-widest hover:bg-gray-300 dark:hover:bg-gray-600">
+                    Volver
+                </a>
+            </div>
+        </div>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            @if (session('status'))
+                <div class="bg-green-100 dark:bg-green-900 border border-green-400 dark:border-green-600 text-green-700 dark:text-green-300 px-4 py-3 rounded relative"
+                    role="alert">
+                    {{ session('status') }}
+                </div>
+            @endif
+
+            <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                <div class="lg:col-span-1">
+                    <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg h-full">
+                        <div class="p-6 text-gray-900 dark:text-gray-100 space-y-4">
+                            <h3 class="text-lg font-semibold">Información del proveedor</h3>
+                            <div>
+                                <p class="text-sm text-gray-500 dark:text-gray-400">Contacto</p>
+                                <p>{{ $provider->contact_name ?? 'No registrado' }}</p>
+                            </div>
+                            <div>
+                                <p class="text-sm text-gray-500 dark:text-gray-400">Correo</p>
+                                <p>{{ $provider->email ?? 'No registrado' }}</p>
+                            </div>
+                            <div>
+                                <p class="text-sm text-gray-500 dark:text-gray-400">Teléfono</p>
+                                <p>{{ $provider->phone ?? 'No registrado' }}</p>
+                            </div>
+                            <div>
+                                <p class="text-sm text-gray-500 dark:text-gray-400">Dirección</p>
+                                <p>{{ $provider->address ?? 'No registrada' }}</p>
+                            </div>
+                            @if ($provider->notes)
+                                <div>
+                                    <p class="text-sm text-gray-500 dark:text-gray-400">Notas</p>
+                                    <p>{{ $provider->notes }}</p>
+                                </div>
+                            @endif
+                            <div>
+                                <p class="text-sm text-gray-500 dark:text-gray-400">Insumos registrados</p>
+                                <p>{{ $provider->supplies->count() }}</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="lg:col-span-2">
+                    <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                        <div class="p-6 text-gray-900 dark:text-gray-100">
+                            <h3 class="text-lg font-semibold mb-4">Agregar insumo</h3>
+                            <form method="POST" action="{{ route('admin.providers.supplies.store', $provider) }}"
+                                class="space-y-4">
+                                @csrf
+
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <div>
+                                        <x-input-label for="name" value="Nombre del insumo" />
+                                        <x-text-input id="name" name="name" type="text" class="mt-1 block w-full"
+                                            value="{{ old('name') }}" required />
+                                        <x-input-error :messages="$errors->get('name')" class="mt-2" />
+                                    </div>
+
+                                    <div>
+                                        <x-input-label for="unit" value="Unidad" />
+                                        <x-text-input id="unit" name="unit" type="text" class="mt-1 block w-full"
+                                            value="{{ old('unit') }}" />
+                                        <x-input-error :messages="$errors->get('unit')" class="mt-2" />
+                                    </div>
+                                </div>
+
+                                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                    <div>
+                                        <x-input-label for="unit_price" value="Precio unitario" />
+                                        <x-text-input id="unit_price" name="unit_price" type="number" min="0" step="0.01"
+                                            class="mt-1 block w-full" value="{{ old('unit_price') }}" />
+                                        <x-input-error :messages="$errors->get('unit_price')" class="mt-2" />
+                                    </div>
+
+                                    <div>
+                                        <x-input-label for="stock" value="Stock" />
+                                        <x-text-input id="stock" name="stock" type="number" min="0" step="1"
+                                            class="mt-1 block w-full" value="{{ old('stock') }}" />
+                                        <x-input-error :messages="$errors->get('stock')" class="mt-2" />
+                                    </div>
+                                </div>
+
+                                <div>
+                                    <x-input-label for="description" value="Descripción" />
+                                    <textarea id="description" name="description" rows="3"
+                                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 dark:bg-gray-900 dark:border-gray-700">{{ old('description') }}</textarea>
+                                    <x-input-error :messages="$errors->get('description')" class="mt-2" />
+                                </div>
+
+                                <div class="flex justify-end">
+                                    <x-primary-button>
+                                        Agregar insumo
+                                    </x-primary-button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 text-gray-900 dark:text-gray-100">
+                    <h3 class="text-lg font-semibold mb-4">Insumos registrados</h3>
+                    @if ($provider->supplies->isEmpty())
+                        <p class="text-sm text-gray-500">No hay insumos registrados para este proveedor.</p>
+                    @else
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                                <thead class="bg-gray-50 dark:bg-gray-700">
+                                    <tr>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                                            Nombre
+                                        </th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                                            Unidad
+                                        </th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                                            Precio unitario
+                                        </th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                                            Stock
+                                        </th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                                            Acciones
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                                    @foreach ($provider->supplies as $supply)
+                                        <tr>
+                                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">
+                                                <div>{{ $supply->name }}</div>
+                                                @if ($supply->description)
+                                                    <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ $supply->description }}</p>
+                                                @endif
+                                            </td>
+                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                                                {{ $supply->unit ?? '—' }}
+                                            </td>
+                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                                                S/ {{ number_format($supply->unit_price, 2) }}
+                                            </td>
+                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">
+                                                {{ $supply->stock }}
+                                            </td>
+                                            <td class="px-6 py-4 whitespace-nowrap text-sm">
+                                                <form method="POST"
+                                                    action="{{ route('admin.providers.supplies.destroy', [$provider, $supply]) }}"
+                                                    onsubmit="return confirm('¿Deseas eliminar este insumo?');">
+                                                    @csrf
+                                                    @method('DELETE')
+                                                    <button type="submit"
+                                                        class="text-red-600 hover:text-red-800 dark:text-red-400">
+                                                        Eliminar
+                                                    </button>
+                                                </form>
+                                            </td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -30,6 +30,9 @@
                         <x-nav-link :href="route('admin.users.index')" :active="request()->routeIs('admin.users.*')">
                             {{ __('Usuarios') }}
                         </x-nav-link>
+                        <x-nav-link :href="route('admin.providers.index')" :active="request()->routeIs('admin.providers.*')">
+                            {{ __('Proveedores') }}
+                        </x-nav-link>
                         {{-- ENLACE AÑADIDO --}}
                         <x-nav-link :href="route('admin.overtime.requests')" :active="request()->routeIs('admin.overtime.requests')">
                             {{ __('Gestionar Horas Extras') }}
@@ -112,6 +115,9 @@
                 </x-responsive-nav-link>
                 <x-responsive-nav-link :href="route('admin.users.index')" :active="request()->routeIs('admin.users.*')">
                     {{ __('Usuarios') }}
+                </x-responsive-nav-link>
+                <x-responsive-nav-link :href="route('admin.providers.index')" :active="request()->routeIs('admin.providers.*')">
+                    {{ __('Proveedores') }}
                 </x-responsive-nav-link>
                 {{-- ENLACE AÑADIDO (Móvil) --}}
                 <x-responsive-nav-link :href="route('admin.overtime.requests')" :active="request()->routeIs('admin.overtime.requests')">

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,7 +2,9 @@
 
 use App\Http\Controllers\AdminController;
 use App\Http\Controllers\Admin\AttendanceController as AdminAttendanceController;
+use App\Http\Controllers\Admin\ProviderController;
 use App\Http\Controllers\Admin\ReceiptController;
+use App\Http\Controllers\Admin\SupplyController;
 use App\Http\Controllers\Admin\ReportsController;
 use App\Http\Controllers\Admin\UserController;
 use App\Http\Controllers\AttendanceController;
@@ -43,6 +45,11 @@ Route::middleware(['auth', 'admin'])->prefix('admin')->name('admin.')->group(fun
     Route::post('/receipts', [ReceiptController::class, 'store'])->name('receipts.store');
     Route::get('/receipts/{receipt}', [ReceiptController::class, 'show'])->name('receipts.show');
     Route::get('/receipts-history', [ReceiptController::class, 'history'])->name('receipts.history');
+
+    // Proveedores e Insumos
+    Route::resource('providers', ProviderController::class);
+    Route::post('/providers/{provider}/supplies', [SupplyController::class, 'store'])->name('providers.supplies.store');
+    Route::delete('/providers/{provider}/supplies/{supply}', [SupplyController::class, 'destroy'])->name('providers.supplies.destroy');
 
     // Gestión de Usuarios
     Route::get('/users', [UserController::class, 'index'])->name('users.index');

--- a/tests/Feature/Admin/ProviderManagementTest.php
+++ b/tests/Feature/Admin/ProviderManagementTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Provider;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProviderManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_create_a_provider(): void
+    {
+        $admin = User::factory()->create(['role' => 'admin']);
+
+        $response = $this->actingAs($admin)->post(route('admin.providers.store'), [
+            'name' => 'Proveedor Uno',
+            'contact_name' => 'Juan Perez',
+            'email' => 'contacto@example.com',
+            'phone' => '987654321',
+            'address' => 'Av. Principal 123',
+            'notes' => 'Proveedor de papelería',
+        ]);
+
+        $provider = Provider::first();
+
+        $response->assertRedirect(route('admin.providers.show', $provider));
+
+        $this->assertDatabaseHas('providers', [
+            'name' => 'Proveedor Uno',
+            'email' => 'contacto@example.com',
+        ]);
+    }
+
+    public function test_admin_can_add_supply_to_provider(): void
+    {
+        $admin = User::factory()->create(['role' => 'admin']);
+        $provider = Provider::factory()->create();
+
+        $response = $this->actingAs($admin)->post(route('admin.providers.supplies.store', $provider), [
+            'name' => 'Resmas de papel',
+            'description' => 'Resma tamaño A4',
+            'unit' => 'Paquete',
+            'unit_price' => 25.5,
+            'stock' => 10,
+        ]);
+
+        $response->assertRedirect(route('admin.providers.show', $provider));
+
+        $this->assertDatabaseHas('supplies', [
+            'provider_id' => $provider->id,
+            'name' => 'Resmas de papel',
+            'stock' => 10,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add database schema, models, and factories to store providers and their supplies
- expose provider CRUD and supply management screens in the admin panel navigation
- cover provider creation and supply linkage with a dedicated feature test

## Testing
- php artisan test --filter=ProviderManagementTest

------
https://chatgpt.com/codex/tasks/task_e_68dd9602113c83239b8386f3bf8278b0