### PR TITLE
Paginate provider supplies list to five items per page

### DIFF
--- a/app/Http/Controllers/Admin/ProviderController.php
+++ b/app/Http/Controllers/Admin/ProviderController.php
@@ -57,9 +57,13 @@ class ProviderController extends Controller
      */
     public function show(Provider $provider): View
     {
-        $provider->load(['supplies' => fn ($query) => $query->orderBy('name')]);
+        $provider->loadCount('supplies');
 
-        return view('admin.providers.show', compact('provider'));
+        $supplies = $provider->supplies()
+            ->orderBy('name')
+            ->paginate(5);
+
+        return view('admin.providers.show', compact('provider', 'supplies'));
     }
 
     /**

--- a/resources/views/admin/providers/show.blade.php
+++ b/resources/views/admin/providers/show.blade.php
@@ -55,7 +55,7 @@
                             @endif
                             <div>
                                 <p class="text-sm text-gray-500 dark:text-gray-400">Insumos registrados</p>
-                                <p>{{ $provider->supplies->count() }}</p>
+                                <p>{{ $provider->supplies_count }}</p>
                             </div>
                         </div>
                     </div>
@@ -122,7 +122,7 @@
             <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6 text-gray-900 dark:text-gray-100">
                     <h3 class="text-lg font-semibold mb-4">Insumos registrados</h3>
-                    @if ($provider->supplies->isEmpty())
+                    @if ($supplies->isEmpty())
                         <p class="text-sm text-gray-500">No hay insumos registrados para este proveedor.</p>
                     @else
                         <div class="overflow-x-auto">
@@ -147,7 +147,7 @@
                                     </tr>
                                 </thead>
                                 <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
-                                    @foreach ($provider->supplies as $supply)
+                                    @foreach ($supplies as $supply)
                                         <tr>
                                             <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900 dark:text-white">
                                                 <div>{{ $supply->name }}</div>
@@ -180,6 +180,11 @@
                                     @endforeach
                                 </tbody>
                             </table>
+                            @if ($supplies->hasPages())
+                                <div class="mt-4">
+                                    {{ $supplies->withQueryString()->links() }}
+                                </div>
+                            @endif
                         </div>
                     @endif
                 </div>


### PR DESCRIPTION
## Summary
- paginate provider supplies on the show view to five rows per page
- display the total supplies count using the preloaded relation count
- render Tailwind pagination controls when additional supplies exist

## Testing
- php artisan test *(fails: missing vendor directory in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de84f6e14c8323a0a6701e4ad2a6d5